### PR TITLE
Try to set the correct height of the iframe on submit

### DIFF
--- a/course_info/templates/course_info/editor.html
+++ b/course_info/templates/course_info/editor.html
@@ -16,8 +16,35 @@
                     widget_url += '&amp;f=' + $(this).val();
                 });
         $('#widget_url').val(widget_url);
+
+        var widget_height = estimateHeight();
+        if (widget_height > 100 && widget_height < 1000) {
+            $("#widget_height").val(widget_height);
+        }
     });
 
+    $("#widget_edit_form_container input").on("change", function(e) {
+      console.log("widget height estimate changed to:", estimateHeight());
+    });
+    
+    // This function attempts to determine the content height for the checked fields .
+    // This value will be used to set the "height" attribute of the iFrame so that it
+    // the content fits.
+   function estimateHeight() {
+      var $checked = $("#widget_edit_form_container input:checked");
+      var $container = $('<div></div>');
+      var height;
+
+      $checked.each(function(idx) {
+         var $field = $(this).next().clone().wrap("<div></div>").parent();
+         $container.append($field);
+      });
+
+      height = $container.hide().appendTo("body").height();
+      $container.remove();
+
+      return height;
+   }
 });
     </script>
 {% endblock %}
@@ -35,12 +62,12 @@
 <form action="{{ launch_presentation_return_url }}" id="widget_edit_form" method="get">
 
 {% for field in fields  %}
-    <div><input id="{{ field.key }}" type="checkbox" value="{{ field.key }}" checked/>{{ field.value }}</div>
+    <div><input id="{{ field.key }}" type="checkbox" value="{{ field.key }}" checked/><span>{{ field.value }}</span></div>
 {% endfor %}
 
     <input type="hidden" id="widget_url" name="url" value="" />
     <input type="hidden" name="width" value="100%" />
-    <input type="hidden" name="height" value="100%" />
+    <input type="hidden" id="widget_height" name="height" value="100%" />
     <input type="hidden" name="title" value="Course Info" />
     <input type="hidden" name="return_type" value="iframe" />
     <input type="submit" name="insert" value="insert" />

--- a/course_info/templates/course_info/widget.html
+++ b/course_info/templates/course_info/widget.html
@@ -5,14 +5,24 @@
 
 {% block extra_js %}
 
-    <script type="text/javascript" charset="utf8">
-    $(document).ready(
-      $(function(){
-         console.log("document height: " +$(document).height());
-        parent.postMessage(JSON.stringify({subject: 'lti.frameResize', height: $(document).height()+"px"}), '*');
-          console.log("did it work?");
-    }));
-    </script>
+
+<script type="text/javascript" charset="utf8">
+// The code below attempts to send a message to the parent window to resize the iFrame to fit the content,
+// which appears to be supported in the Instructure codebase here:
+//
+// https://github.com/instructure/canvas-lms/blob/master/public/javascripts/tool_inline.js
+//
+// However, for one reason or another, this doesn't sem to be working, so commenting out (for now).
+/*
+   $(document).ready(function() {
+      window.postMessage(JSON.stringify({
+         subject: 'lti.frameResize',
+         height: $(document).height()
+      }), '*');
+   });
+*/
+</script>
+
 
 {% endblock %}
 


### PR DESCRIPTION
I tried a different approach to the problem of getting the iFrame to fit the content. Instead of resizing the iFrame on the page, this attempts to estimate the content height when the user is selecting which fields they want to display, and setting the height of the frame when they submit their selections. It's not perfect, but it seems to work reasonably well. 

@brainheart What do you think?

--Artie
