### PR TITLE
remove email settings (i.e. mandrill addon); rely on loggly drain + loggly alerts

### DIFF
--- a/dce_course_info/settings.py
+++ b/dce_course_info/settings.py
@@ -26,7 +26,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'djrill',
     'course_info'
 )
 
@@ -82,16 +81,6 @@ LTI_APPS = {
 
 SECRET_KEY = env('DJANGO_SECRET_KEY', required=True)
 
-# this tells django who to send app error emails to
-ADMINS = ((env('DJANGO_ADMIN_NAME'), env('DJANGO_ADMIN_EMAIL')),)
-
-# From: addr of the app error emails
-SERVER_EMAIL = env('DJANGO_SERVER_EMAIL', 'root@localhost')
-
-# use mandrill to send app error emails
-EMAIL_BACKEND = "djrill.mail.backends.djrill.DjrillBackend"
-MANDRILL_API_KEY = env('MANDRILL_APIKEY')
-
 # depends on DATABASE_URL being set in your env. See https://github.com/kennethreitz/dj-database-url
 # you can also set DJANGO_DATABASE_DEFAULT_ENGINE if you want to override the
 # default engine, e.g., using https://github.com/kennethreitz/django-postgrespool/
@@ -138,11 +127,6 @@ LOGGING = {
         },
     },
     'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
@@ -154,7 +138,7 @@ LOGGING = {
     },
     'loggers': {
         'django.request': {
-            'handlers': ['mail_admins', 'console'],
+            'handlers': ['console'],
             'level': 'ERROR',
             'propagate': True,
         },

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -47,20 +47,16 @@ brew install redis
 
 Something like this:
 
-DJANGO_SETTINGS_MODULE=dce_course_info.settings
-DJANGO_SECRET_KEY=make_something_actually_secret
-LTI_OAUTH_COURSE_INFO_CONSUMER_KEY=your_key
-LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET=your_secret
-DATABASE_URL=postgres://dce_course_info:password@127.0.0.1:5432/dce_course_info
-DJANGO_ADMIN_NAME=somebody
-DJANGO_ADMIN_EMAIL=somebody@harvard.edu
-DJANGO_SERVER_EMAIL=somebody@harvard.edu
-DJANGO_DATABASE_DEFAULT_ENGINE=django_postgrespool
-MANDRILL_APIKEY=your_api_key
-ICOMMONS_BASE_URL=https://icommons.harvard.edu
-ICOMMONS_API_TOKEN=your_api_token
-DREST_DEBUG=55
-REDIS_URL=http://localhost:6379
+    DJANGO_SETTINGS_MODULE=dce_course_info.settings
+    DJANGO_SECRET_KEY=make_something_actually_secret
+    LTI_OAUTH_COURSE_INFO_CONSUMER_KEY=your_key
+    LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET=your_secret
+    DATABASE_URL=postgres://dce_course_info:password@127.0.0.1:5432/dce_course_info
+    DJANGO_DATABASE_DEFAULT_ENGINE=django_postgrespool
+    ICOMMONS_BASE_URL=https://icommons.harvard.edu
+    ICOMMONS_API_TOKEN=your_api_token
+    DREST_DEBUG=55
+    REDIS_URL=http://localhost:6379
 
 Do not stick your .env file in source control. This stuff is sensitive.
 

--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -3,18 +3,19 @@
 ### From scratch
 
 1. Create a new Heroku app. For the purposes of these instructions we'll call it "dce-course-info", but it could really be anything.
-2. Install the [heroku-toolbelt](https://toolbelt.heroku.com/).
-3. Clone the [dce_course_info](https://github.com/harvard-dce/dce_course_info repo).
-4. Run `heroku git:remote -a dce-course-info`
-5. Add the required heroku add-ons: 
+1. Install the [heroku-toolbelt](https://toolbelt.heroku.com/).
+1. Clone the [dce_course_info](https://github.com/harvard-dce/dce_course_info repo).
+1. Run `heroku git:remote -a dce-course-info`
+1. Add the required heroku add-ons: 
     * [Heroku Postgres](https://addons.heroku.com/heroku-postgresql) 
-    * [Mandrill](https://addons.heroku.com/mandrill)
     * [RedisToGo](https://elements.heroku.com/addons/redistogo)
-6. Set up the remaining environment vars via `heroku config:set ...` (see below)
-7. Run `git push heroku master`. Heroku will detect and build the app.
-8. Run `heroku run python manage.py migrate` to initialize the database. 
+1. Set up the remaining environment vars via `heroku config:set ...` (see below)
+1. Create a loggly logging drain:
+    * `heroku drains:add https://logs-01.loggly.com/bulk/<loggly token>/tag/heroku,dce-course-admin`
+1. Run `git push heroku master`. Heroku will detect and build the app.
+1. Run `heroku run python manage.py migrate` to initialize the database. 
     * Up to you whether you want to create an admin user. The app doesn't require it.
-9. Install the LTI app in the Canvas account settings UI. 
+1. Install the LTI app in the Canvas account settings UI. 
     * Configuration Type: 'By URL'
     * Name: 'Course Info'
     * Consumer Key: value of the **LTI_OAUTH_COURSE_INFO_CONSUMER_KEY** env var
@@ -23,32 +24,21 @@
 
 ### Required env vars
 
-```
-LTI_OAUTH_COURSE_INFO_CONSUMER_KEY=...
-LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET=...
-DJANGO_SECRET_KEY=...
-DJANGO_ADMIN_NAME=...
-DJANGO_ADMIN_EMAIL=...
-DJANGO_SERVER_EMAIL
-PYTHONPATH=fakepath
-DJANGO_DATABASE_DEFAULT_ENGINE=django_postgrespool
-REDIS_URL=...
-```
+    LTI_OAUTH_COURSE_INFO_CONSUMER_KEY=...
+    LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET=...
+    DJANGO_SECRET_KEY=...
+    PYTHONPATH=fakepath
+    DJANGO_DATABASE_DEFAULT_ENGINE=django_postgrespool
+    REDIS_URL=...
 
 * **LTI_OAUTH_COURSE_INFO_CONSUMER_KEY** and **LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET** are credentials needed during the Canvas LTI app installation. The key should be some simple, identifying string, like "dce-course-admin". For the secret you can probably just use a generated password or a [uuid4](http://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29), but if you want to get fancy there's a [secret key generator](http://techblog.leosoto.com/django-secretkey-generation/) that I sometimes use.
 * **DJANGO_SECRET_KEY**: see comments above about the *LTI_OAUTH_COURSE_INFO_CONSUMER_SECRET*.
 * **PYTHONPATH**: This is a common kludge to deal with [gunicorn weirdness on heroku](https://github.com/heroku/heroku-buildpack-python/wiki/Troubleshooting#no-module-named-appwsgiapp).
-* **DJANGO_ADMIN_NAME** and **DJANGO_ADMIN_EMAIL**: Set these to the name/email of the person or entity that will recieve app error notifications.
-* **DJANGO_SERVER_EMAIL**: app error notifications will use this as the "From:" address.
 * **REDIS_URL**: copy this from the **REDISTOGO_URL** that was inserted into your heroku config when the redis add-on was added.
 
 ### Additional env vars
 
-```
-DATABASE_URL=...
-MANDRILL_APIKEY=...
-MANDRILL_USERNAME=...
-```
+    DATABASE_URL=...
 
 These are all provided by add-ons; do not set them manually.
 

--- a/requirements/dce.txt
+++ b/requirements/dce.txt
@@ -2,4 +2,3 @@
 
 django-toolbelt==0.0.1
 django-postgrespool==0.3.0
-djrill==1.3.0


### PR DESCRIPTION
The free Mandrill addon for heroku is being EOL'd. The raison d'etre for this functionality was for emailing error occurrences to some designated "admin" address. Rather than switch to a different free email service, I decided to simply remove this feature in favor of a loggly logging drain + loggly alerts.
